### PR TITLE
fix: make `params` an optional argument in requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,7 @@ export default class AxiosWrapper {
     }
 
     async request<T = any>(methodParams: ApiMethodParams): Promise<T> {
-        const {method, url, data = null, params, options = {}, retries = 0} = methodParams;
+        const {method, url, data = null, params = {}, options = {}, retries = 0} = methodParams;
 
         const axiosSettings: AxiosRequestConfig = options.requestConfig || {};
         const {concurrentId, collectRequest = true, timeout, headers} = options;
@@ -207,8 +207,8 @@ export default class AxiosWrapper {
 
     get<T = any>(
         url: string,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'GET',
@@ -221,8 +221,8 @@ export default class AxiosWrapper {
     post<T = any>(
         url: string,
         data: unknown,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'POST',
@@ -236,8 +236,8 @@ export default class AxiosWrapper {
     put<T = any>(
         url: string,
         data: unknown,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'PUT',
@@ -251,8 +251,8 @@ export default class AxiosWrapper {
     patch<T = any>(
         url: string,
         data: unknown,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'PATCH',
@@ -266,8 +266,8 @@ export default class AxiosWrapper {
     delete<T = any>(
         url: string,
         data: unknown,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'DELETE',
@@ -280,8 +280,8 @@ export default class AxiosWrapper {
 
     head<T = any>(
         url: string,
-        params: ApiMethodParams['params'],
-        options: ApiMethodParams['options'] = {},
+        params?: ApiMethodParams['params'],
+        options?: ApiMethodParams['options'],
     ) {
         return this.request<T>({
             method: 'HEAD',


### PR DESCRIPTION
This will allow to not invoke, e.g. `api.get('/foo', {})`, when one can
simply invoke `api.get('/foo')`.

Closes #7.